### PR TITLE
fix: block generic state handlers with `G.GAME.STOP_USE`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -17,7 +17,7 @@ return function(Controller, key) -- order defines precedence
   then -- nothing :)
   elseif G.SETTINGS.paused then
     require("typist.state-handlers")[G.STATES.MENU](key)
-  elseif require("typist.state-handlers")[G.STATE] then
+  elseif require("typist.state-handlers")[G.STATE] and G.GAME.STOP_USE == 0 then
     require("typist.state-handlers")[G.STATE](key, Controller.held_keys)
   end
 


### PR DESCRIPTION
this slows down some actions that worked normally before, but eliminates all "keybind pressed too early" crashes, so i think it's fine