### PR TITLE
Revert "compat(WilsontheWolf/DebugPlus): move the entire keyboard except `debugplus.console` behind `ctrl` in debug mode"

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -10,19 +10,12 @@ times = 1
 pattern = "function Controller:key_hold_update(key, dt)"
 payload = '''
 local key_press_update_impl = Controller.key_press_update
-local is_mac = love.system.getOS() == 'OS X'
-local debug_leader_right = is_mac and 'rgui' or 'rctrl'
-local debug_leader_left = is_mac and 'lgui' or 'lctrl'
 function Controller:key_press_update(key, dt)
-  if not _RELEASE_MODE then
-    if
-      consoleOpen
-      or self.held_keys[debug_leader_right]
-      or self.held_keys[debug_leader_left]
-    then
-      return key_press_update_impl(self, key, dt)
-    else
+  if G.DEBUG then
+    if self.held_keys["lctrl"] then
       require("typist")(self, key, dt)
+    else
+      return key_press_update_impl(self, key, dt)
     end
   else
     require("typist")(self, key, dt)

--- a/lovely.toml
+++ b/lovely.toml
@@ -9,13 +9,16 @@ position = "before"
 times = 1
 pattern = "function Controller:key_hold_update(key, dt)"
 payload = '''
-local __typist_layout = require("typist.mod.layout")
 local key_press_update_impl = Controller.key_press_update
+local is_mac = love.system.getOS() == 'OS X'
+local debug_leader_right = is_mac and 'rgui' or 'rctrl'
+local debug_leader_left = is_mac and 'lgui' or 'lctrl'
 function Controller:key_press_update(key, dt)
   if not _RELEASE_MODE then
     if
-      self.held_keys[__typist_layout.debug_leader_left]
-      or self.held_keys[__typist_layout.debug_leader_right]
+      consoleOpen
+      or self.held_keys[debug_leader_right]
+      or self.held_keys[debug_leader_left]
     then
       return key_press_update_impl(self, key, dt)
     else

--- a/mod/init.lua
+++ b/mod/init.lua
@@ -2,25 +2,6 @@ local layout = require("typist.mod.layout")
 
 print(layout.tostring())
 
-local debugplus_consoleHandleKey = require("debugplus.console")
-  and require("debugplus.console").consoleHandleKey
-if debugplus_consoleHandleKey then
-  print("DebugPlus detected, moving it behind the `ctrl` key to avoid conflicts")
-  local held_keys = G.CONTROLLER and G.CONTROLLER.held_keys
-  local debugplus_consoleOpen = false
-  require("debugplus.console").consoleHandleKey = function(key)
-    if
-      debugplus_consoleOpen
-      or held_keys[layout.debug_leader_left]
-      or held_keys[layout.debug_leader_right]
-    then
-      debugplus_consoleOpen = not debugplus_consoleHandleKey(key) or key == "/"
-      return not debugplus_consoleOpen
-    end
-    return true
-  end
-end
-
 if fhotkey then
   print("FlushHotkeys detected, unhooking it from the keyboard :)")
   Controller.key_press_update = assert(fhotkey.FUNCS.keyupdate_ref)
@@ -45,8 +26,6 @@ return function(Controller, key) -- order defines precedence
     require("typist.mod.state-handlers")[G.STATES.MENU](key)
   elseif require("typist.mod.state-handlers")[G.STATE] then
     require("typist.mod.state-handlers")[G.STATE](key, Controller.held_keys)
-  elseif key == "escape" then
-    if not G.OVERLAY_MENU then G.FUNCS:options() end
   end
 
   -- can be invoked anywhere with no consideration for state or precedence

--- a/mod/layout.lua
+++ b/mod/layout.lua
@@ -94,10 +94,6 @@ M.buy_and_use = ({
 M.enter = "return"
 M.escape = "escape"
 
-local is_mac = love.system.getOS() == "OS X"
-M.debug_leader_left = is_mac and "lgui" or "lctrl"
-M.debug_leader_right = is_mac and "rgui" or "rctrl"
-
 local function subscript_fields(keymap, l)
   local res = {}
   for k, v in pairs(keymap) do

--- a/mod/state-handlers.lua
+++ b/mod/state-handlers.lua
@@ -19,7 +19,7 @@ M[G.STATES.SELECTING_HAND] = function(key, held_keys)
       blocking = false,
       blockable = false,
       func = function()
-        if not G.CONTROLLER.held_keys[layout.preview_deck] then
+        if not (tu.dig(G, { "CONTROLLER", "held_keys", layout.preview_deck })) then
           G.deck_preview:remove()
           G.deck_preview = nil
           return true

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,6 @@ other mods:
 - [V-rtualized/BalatroMultiplayer v0.1.8.4](https://github.com/V-rtualized/BalatroMultiplayer/releases/tag/0.1.8.4)
   - on pvp blinds `space` toggles the ready state instead of immediately starting the blind
   - in lobby menu `space` starts the run (if you're the host)
-- [WilsontheWolf/DebugPlus v1.4.1](https://github.com/WilsontheWolf/DebugPlus/releases/tag/v1.4.1)
-  - hold `ctrl` as a leader for the entire keyboard except `typist` if the game is in debug mode
 - [Amvoled/Taikomochi `9a99c3a`](https://github.com/Amvoled/Taikomochi/tree/9a99c3a12c11573a5a16d9b6c11737307d3d25d8)
   - `enter` on the game over screen retries the last ante for zen mode runs
 - [Agoraaa/FlushHotkeys `4c0b1df`](https://github.com/Agoraaa/FlushHotkeys)

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ other mods:
   - on pvp blinds `space` toggles the ready state instead of immediately starting the blind
   - in lobby menu `space` starts the run (if you're the host)
 - [WilsontheWolf/DebugPlus v1.4.1](https://github.com/WilsontheWolf/DebugPlus/releases/tag/v1.4.1)
-  - hold `ctrl` as a leader for the entire keyboard except `typist` and `debugplus.console` if the game is in debug mode
+  - hold `ctrl` as a leader for the entire keyboard except `typist` if the game is in debug mode
 - [Amvoled/Taikomochi `9a99c3a`](https://github.com/Amvoled/Taikomochi/tree/9a99c3a12c11573a5a16d9b6c11737307d3d25d8)
   - `enter` on the game over screen retries the last ante for zen mode runs
 - [Agoraaa/FlushHotkeys `4c0b1df`](https://github.com/Agoraaa/FlushHotkeys)


### PR DESCRIPTION
Reverts janw4ld/balatro-typist-mod#34