### PR TITLE
fix: prevent leader key conflicts with rank selection

### DIFF
--- a/mod/layout.lua
+++ b/mod/layout.lua
@@ -155,7 +155,6 @@ M.cheat = tu.override_merge(subscript_fields({
   best_hand = "b",
   best_flush = "f",
   suits_map = { s = "Spades", d = "Diamonds", c = "Clubs", h = "Hearts" },
-  -- TODO: fix jqk conflict in dvorak
   ranks_map =  {
     ["2"] = 2, ["3"] = 3, ["4"] = 4, ["5"] = 5, ["6"] = 6, ["7"] = 7, ["8"] = 8,
     ["9"] = 9, ["0"] = 10, ["1"] = 10, ["j"] = 11, ["q"] = 12, ["k"] = 13, ["a"] = 14,

--- a/mod/state-handlers.lua
+++ b/mod/state-handlers.lua
@@ -98,9 +98,15 @@ cheat_layer = function(key, held_keys)
   -- select by suit
   elseif layout.cheat.suits_map[key] then
     hand.flush(layout.cheat.suits_map[key])
-  -- select by rank
+  -- select by rank - avoid conflict with leader keys when not being used as a shortcut
   elseif layout.cheat.ranks_map[key] then
-    hand.by_rank(layout.cheat.ranks_map[key])
+    if -- only allow a leader key to pass when another leader key is held
+      not (key == layout.cheat.leader_left or key == layout.cheat.leader_right)
+      or (key == layout.cheat.leader_left and held_keys[layout.cheat.leader_right])
+      or (key == layout.cheat.leader_right and held_keys[layout.cheat.leader_left])
+    then
+      hand.by_rank(layout.cheat.ranks_map[key])
+    end
   -- because why not
   elseif
     key == layout.proceed


### PR DESCRIPTION
## Summary
- Fixed the issue where tapping 'Q' in QWERTY layout would erroneously trigger both leader key and rank selection (Queen) functionality
- Implemented smarter leader key detection that preserves all functionality while resolving conflicts